### PR TITLE
fix: show selected template in note preview for new notebooks

### DIFF
--- a/app/src/main/java/com/github/bytesculptor07/quillo/MainActivity.java
+++ b/app/src/main/java/com/github/bytesculptor07/quillo/MainActivity.java
@@ -941,9 +941,7 @@ public class MainActivity extends AppCompatActivity {
             if (data != null) {
                 thumbnail = createThumbnail(GeneralUtils.dpToPx(MainActivity.this, 150), GeneralUtils.dpToPx(MainActivity.this, (int) (150 * 2970f / 2100f)), data, background);
             } else {
-                thumbnail = Bitmap.createBitmap(GeneralUtils.dpToPx(MainActivity.this, 150), GeneralUtils.dpToPx(MainActivity.this, (int) (150 * 2970f / 2100f)), Bitmap.Config.ARGB_8888);
-                Canvas canvas = new Canvas(thumbnail);
-                canvas.drawColor(Color.WHITE);
+                thumbnail = createBackgroundThumbnail(GeneralUtils.dpToPx(MainActivity.this, 150), GeneralUtils.dpToPx(MainActivity.this, (int) (150 * 2970f / 2100f)), background);
             }
         } catch(Exception e) {
             Toast.makeText(MainActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
This PR addresses issue #4 by ensuring that when a new notebook is created without any data, the selected background template is correctly shown in the note preview screen.

## What’s been added

Updated the logic inside the `createNote(String noteid)` method in MainActivity.java. Instead of showing a plain white bitmap when the notebook has no drawing data, the app now calls `createBackgroundThumbnail(...)` to generate a preview that reflects the selected template.

**The background preview is now visually aligned with the user's template selection during notebook creation.**

<img width="419" height="879" alt="Quillo - Template in note preview" src="https://github.com/user-attachments/assets/6ddf2b45-5983-4a70-b620-f2daf90a6bd9" />

## Additional Notes

- No changes were made to the behavior when drawing data exists` (data != null)`; that path still uses `createThumbnail(...)`.
- The implementation uses existing helper methods and keeps changes minimal and focused on the issue at hand.
