### PR TITLE
Fix bottom navigation bar not visible in portrait mode

### DIFF
--- a/app/src/main/java/com/github/bytesculptor07/quillo/MainActivity.java
+++ b/app/src/main/java/com/github/bytesculptor07/quillo/MainActivity.java
@@ -37,6 +37,8 @@ import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
 import com.dropbox.core.oauth.DbxCredential;
 import com.dropbox.core.json.JsonReadException;
 import com.dropbox.core.v2.users.FullAccount;
@@ -118,6 +120,12 @@ public class MainActivity extends AppCompatActivity {
     }
     
     public void initLandscape() {
+        // Hide bottom navigation in landscape mode
+        BottomNavigationView bottomNavigation = findViewById(R.id.bottom_navigation);
+        if (bottomNavigation != null) {
+            bottomNavigation.setVisibility(View.GONE);
+        }
+        
         LinearLayout notebooks = findViewById(R.id.notebooks);
         LinearLayout sharednotebooks = findViewById(R.id.sharednotebooks);
         LinearLayout templates = findViewById(R.id.templates);
@@ -138,6 +146,33 @@ public class MainActivity extends AppCompatActivity {
     public void initPortrait() {
         FrameLayout layout = findViewById(R.id.fragmentContainer);
         adjustStatusBar(layout);
+        
+        // Set up bottom navigation
+        BottomNavigationView bottomNavigation = findViewById(R.id.bottom_navigation);
+        bottomNavigation.setVisibility(View.VISIBLE); // Ensure it's visible in portrait mode
+        bottomNavigation.setOnItemSelectedListener(item -> {
+            int itemId = item.getItemId();
+            if (itemId == R.id.nav_notebooks) {
+                menuChange(null, homeFrag);
+                return true;
+            } else if (itemId == R.id.nav_shared) {
+                menuChange(null, sharednotebooksFrag);
+                return true;
+            } else if (itemId == R.id.nav_flashcards) {
+                menuChange(null, flashcardsFrag);
+                return true;
+            } else if (itemId == R.id.nav_statistics) {
+                menuChange(null, statisticsFrag);
+                return true;
+            } else if (itemId == R.id.nav_settings) {
+                menuChange(null, settingsFrag);
+                return true;
+            }
+            return false;
+        });
+        
+        // Set default selected item
+        bottomNavigation.setSelectedItemId(R.id.nav_notebooks);
     }
 
     private void createFragment(Fragment fragment, boolean replace){

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -12,7 +12,8 @@
     
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:id="@+id/fragmentContainer">
     </FrameLayout>
     
@@ -20,11 +21,9 @@
         android:id="@+id/bottom_navigation"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
         app:menu="@menu/bottom_nav_menu"
         app:itemIconTint="@color/primary"
         app:itemActiveIndicatorStyle="@style/Theme.BottomNavigationView.ActiveIndicator"
-        app:labelVisibilityMode="labeled"
-        android:layout_alignParentBottom="true"/>
+        app:labelVisibilityMode="labeled"/>
 
 </LinearLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -7,14 +7,17 @@
     <item
         android:id="@+id/nav_shared"
         android:icon="@drawable/icon_shared"
-        android:title="@string/menu_shared" />
+        android:title="@string/menu_shared_notebooks" />
     <item
         android:id="@+id/nav_flashcards"
         android:icon="@drawable/icon_flashcards"
         android:title="@string/menu_flashcards" />
     <item
+        android:id="@+id/nav_statistics"
+        android:icon="@drawable/icon_statistics"
+        android:title="@string/menu_statistics" />
+    <item
         android:id="@+id/nav_settings"
         android:icon="@drawable/icon_settings"
-        
         android:title="@string/menu_settings" />
 </menu>


### PR DESCRIPTION
Fixes #24

- Fixed layout issue where FrameLayout took full height, pushing bottom nav off-screen
- Added proper weight distribution (0dp height + weight=1) for fragment container
- Implemented complete bottom navigation logic in initPortrait() method
- Added visibility controls: show in portrait, hide in landscape mode
- Updated bottom nav menu to include all main features (5 items total)
- Fixed string reference for shared notebooks menu item

The bottom navigation now properly displays and functions in portrait mode while maintaining the existing sidebar navigation in landscape mode.

Changes:
- MainActivity.java: Added BottomNavigationView setup and orientation handling
- activity_main.xml: Fixed layout weights for proper space allocation
- bottom_nav_menu.xml: Added statistics item and fixed string references

Tested: Builds successfully without compilation errors